### PR TITLE
Bug fix for unaccounted bottom array rotation in NaI detectorID assig…

### DIFF
--- a/src/k100_ZipSD.cc
+++ b/src/k100_ZipSD.cc
@@ -80,7 +80,7 @@ G4bool k100_ZipSD::ProcessHits(G4Step* aStep, G4TouchableHistory* /*ROhist*/)
 
   dataVector[1-1]  = 0; // Is not set in this function
   if(!strcmp(aStep->GetPreStepPoint()->GetTouchable()->GetVolume()->GetLogicalVolume()->GetName(),"NaI_tile_LV")) {
-    if(abs(aStep->GetPreStepPoint()->GetPosition().x()) < 0.5*(324.0 + 20.0) ) { // For bottom NaI array
+    if(abs(aStep->GetPreStepPoint()->GetPosition().x()) < 0.5*(406.0 + 20.0) ) { // For bottom NaI array
       dataVector[2-1] = 1000 + aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber() + 1;
     }
     else { // For vertical NaI array


### PR DESCRIPTION
This PR fixes the bug in detectorID assignment of bottom NaI array. 

The previous version does not take the rotation of bottom array geometry into account for detectorID assignment thus assigning vertical array detID to G4Step beyond _unrotated_ bottom array. In this PR, I have fixed the x-position range.



